### PR TITLE
Remove log-linear interpolation

### DIFF
--- a/tokamak_neutron_source/openmc_interface.py
+++ b/tokamak_neutron_source/openmc_interface.py
@@ -49,7 +49,7 @@ def get_neutron_energy_spectrum(
     """
     energy, probability = energy_spectrum(temp_kev, reaction, method)
     energy_ev = raw_uc(energy, "keV", "eV")
-    # TODO: Log-linear interpolation is not supported in OpenMC at present
+    # Log-linear interpolation is not supported in OpenMC at present
     # see: https://github.com/openmc-dev/openmc/issues/2409
     return Tabular(energy_ev, probability, interpolation="linear-linear")
 

--- a/tokamak_neutron_source/openmc_interface.py
+++ b/tokamak_neutron_source/openmc_interface.py
@@ -49,7 +49,9 @@ def get_neutron_energy_spectrum(
     """
     energy, probability = energy_spectrum(temp_kev, reaction, method)
     energy_ev = raw_uc(energy, "keV", "eV")
-    return Tabular(energy_ev, probability, interpolation="log-linear")
+    # TODO: Log-linear interpolation is not supported in OpenMC at present
+    # see: https://github.com/openmc-dev/openmc/issues/2409
+    return Tabular(energy_ev, probability, interpolation="linear-linear")
 
 
 def make_openmc_ring_source(


### PR DESCRIPTION
This is not presently supported in OpenMC at the moment. Presently raises:

```RuntimeError: Unsupported interpolation type for distribution: log-linear```