### PR TITLE
Double T-T neutrons

### DIFF
--- a/tokamak_neutron_source/openmc_interface.py
+++ b/tokamak_neutron_source/openmc_interface.py
@@ -124,7 +124,13 @@ def make_openmc_full_combined_source(
     """
     sources = []
     # Neutronic reaction channels only
-    n_strength = {k: v for k, v in strength.items() if isinstance(k, Reactions)}
+    # We multiply the T-T channel by 2 because it is 2n
+    n_strength = {
+        k: (v * 2 if k == Reactions.T_T else v)
+        for k, v in strength.items()
+        if isinstance(k, Reactions)
+    }
+
 
     for i, (ri, zi, ti) in enumerate(zip(r, z, temperature, strict=False)):
         distributions = []

--- a/tokamak_neutron_source/openmc_interface.py
+++ b/tokamak_neutron_source/openmc_interface.py
@@ -131,7 +131,6 @@ def make_openmc_full_combined_source(
         if isinstance(k, Reactions)
     }
 
-
     for i, (ri, zi, ti) in enumerate(zip(r, z, temperature, strict=False)):
         distributions = []
         weights = []

--- a/tokamak_neutron_source/reactivity.py
+++ b/tokamak_neutron_source/reactivity.py
@@ -79,7 +79,7 @@ def density_weighted_reactivity(
         case Reactions.D_T:
             n1_n2 = density_d * density_t
         case Reactions.T_T:
-            # Here the Kronecker term (1/1+1) because they are the same
+            # Here the Kronecker term is (1/1+1) because they are the same
             # species, but we have a single energy spectrum for both T-T
             # neutrons, so we multiply again by 2
             n1_n2 = density_t * density_t

--- a/tokamak_neutron_source/reactivity.py
+++ b/tokamak_neutron_source/reactivity.py
@@ -79,10 +79,7 @@ def density_weighted_reactivity(
         case Reactions.D_T:
             n1_n2 = density_d * density_t
         case Reactions.T_T:
-            # Here the Kronecker term is (1/1+1) because they are the same
-            # species, but we have a single energy spectrum for both T-T
-            # neutrons, so we multiply again by 2
-            n1_n2 = density_t * density_t
+            n1_n2 = density_t * density_t / 2
         case AneutronicReactions.D_He3:
             n1_n2 = density_d * density_he3
         case _:

--- a/tokamak_neutron_source/reactivity.py
+++ b/tokamak_neutron_source/reactivity.py
@@ -79,7 +79,10 @@ def density_weighted_reactivity(
         case Reactions.D_T:
             n1_n2 = density_d * density_t
         case Reactions.T_T:
-            n1_n2 = density_t * density_t / 2
+            # Here the Kronecker term (1/1+1) because they are the same
+            # species, but we have a single energy spectrum for both T-T
+            # neutrons, so we multiply again by 2
+            n1_n2 = density_t * density_t
         case AneutronicReactions.D_He3:
             n1_n2 = density_d * density_he3
         case _:


### PR DESCRIPTION
I decided not to do this in the reactivity calculation (which just calculates the reaction rate), and also not in the main `TokamakNeutronSource` class, because it would mess with the fusion power calculation.

In the end I put it directly in how the source for OpenMC is calculated. Once we have the SDEF stuff, we can think of a more general way of doing this.