### PR TITLE
Improved TT neutron energy

### DIFF
--- a/tokamak_neutron_source/constants.py
+++ b/tokamak_neutron_source/constants.py
@@ -342,6 +342,13 @@ E_TT_FUSION: float = raw_uc(
     "J",
 )
 
+# The Q value of the t + t -> 5He + n reaction, which is an intermediate state of the
+# t + t -> 4He + n + n reaction.
+_TT_TO_5HE_Q_VALUE = raw_uc(10597, "keV", "J")
+_5HE_TO_4HE_Q_VALUE = E_TT_FUSION - _TT_TO_5HE_Q_VALUE
+E_TT_NEUTRON: float = (_TT_TO_5HE_Q_VALUE * 5 / 6 + _5HE_TO_4HE_Q_VALUE * 4 / 5) / 2
+
+
 # The energy released from a single D-3He fusion reaction [J]
 # 18.354208506129673 MeV
 E_DHE3_FUSION = raw_uc(

--- a/tokamak_neutron_source/reactions.py
+++ b/tokamak_neutron_source/reactions.py
@@ -15,6 +15,7 @@ from tokamak_neutron_source.constants import (
     E_DT_FUSION,
     E_DT_NEUTRON,
     E_TT_FUSION,
+    E_TT_NEUTRON,
 )
 from tokamak_neutron_source.energy_data import (
     BALLABIO_DD_NEUTRON,
@@ -136,7 +137,7 @@ AllReactions: TypeAlias = Reactions | AneutronicReactions
 _APPROX_NEUTRON_ENERGY = {
     Reactions.D_D: E_DD_NEUTRON,
     Reactions.D_T: E_DT_NEUTRON,
-    Reactions.T_T: E_TT_FUSION * (1 - 1 / 6 * 1 / 5) / 2,
+    Reactions.T_T: E_TT_NEUTRON,
     # assuming sequential ejection of two neutrons by the TT cluster at classical speeds.
     AneutronicReactions.D_D: 0.0,
     AneutronicReactions.D_He3: 0.0,


### PR DESCRIPTION
Previously [I mentioned](https://github.com/Fusion-Power-Plant-Framework/tokamak-neutron-source/pull/26#discussion_r2419420931) that the _APPROX_NEUTRON_ENERGY[Reactions.T_T] gives an incorrect E, and now after speaking to a nuclear physicist I understood why.

Surprisingly I may be correct that the TT reaction proceeds as such: `t + t → 5He + n → 4He + n + n`. The first step has Q-value=10597 keV. Taking into account this intermediate state, this means that 5/6 of the 10.597 MeV is transferred into the first neutron, and then 4/5 of the remaining Q-value is transferred into the second neutron. The sum of these two leads to an energy equal to 83.1% of the full Q-value, much closer to the data's value (81.5% of the full Q-value) compared to the existing branch's.

The neutron spectrum also reflect this quite well: the triton (reactant) temperature only causes thermal broadening in the first neutron's peak (at 5/6 * 10.597 = 8.83MeV), while having less effect on the already broadened second peak at lower energy.
<img width="793" height="442" alt="image" src="https://github.com/user-attachments/assets/3e27fe56-609e-4f0f-9802-4d34ad76ad00" />
